### PR TITLE
feature/foss-gapps

### DIFF
--- a/installer/01-setup_lxd.sh
+++ b/installer/01-setup_lxd.sh
@@ -3,7 +3,7 @@
 CYAN='\e[1;36m'
 RESET='\e[0m'
 
-REPO_URL='https://github.com/supechicken/ChromeOS-Waydroid-Installer/raw/refs/heads/main'
+REPO_URL='https://github.com/neilgfoster/cros-waydroid-installer/raw/refs/heads/main'
 
 # Simplify colors and print errors to stderr (2).
 echo_error() { echo -e "\e[1;91m${*}${RESET}" >&2; } # Use Light Red for errors.

--- a/installer/02-setup_waydroid.sh
+++ b/installer/02-setup_waydroid.sh
@@ -3,17 +3,7 @@
 CYAN='\e[1;36m'
 RESET='\e[0m'
 
-REPO_URL='https://github.com/supechicken/ChromeOS-Waydroid-Installer/raw/refs/heads/main'
-
-ANDROID13_TV_IMG_X86=(
-  https://github.com/supechicken/waydroid-androidtv-build/releases/download/20250327/lineage-20.0-20250327-UNOFFICIAL-WaydroidATV_x86_64.zip
-  44d77c229f4737dfca6e360cdc06a6a2860717b504038b11b0216ed8a51f6a5a
-)
-
-ANDROID13_TV_IMG_ARM=(
-  https://github.com/supechicken/waydroid-androidtv-build/releases/download/20250225/lineage-20.0-20250226-UNOFFICIAL-WaydroidATV_arm64.zip
-  4ac4cc286ac3c0238735bbb4efad9b45c94ef80a93e3195c1e5f77a19216efd5
-)
+REPO_URL='https://github.com/neilgfoster/cros-waydroid-installer/raw/refs/heads/main'
 
 # Simplify colors and print errors to stderr (2).
 echo_error() { echo -e "\e[1;91m${*}${RESET}" >&2; } # Use Light Red for errors.
@@ -58,7 +48,8 @@ cat <<EOT
 Select an Android version to install:
 
   1. Android 13
-  2. Android 13 TV
+  2. Android 13 FOSS
+  3. Android 13 GAPPS
 
 EOT
 
@@ -75,37 +66,12 @@ case "${ANDROID_VERSION}" in
   sudo waydroid init -s VANILLA
 ;;
 2)
-  ANDROID_VERSION='Android 13 TV'
-  case "$(uname -m)" in
-  arm*|aarch64)
-    ANDROID_IMG_URL="${ANDROID13_TV_IMG_ARM[0]}"
-    ANDROID_IMG_SHA="${ANDROID13_TV_IMG_ARM[1]}"
-  ;;
-  x86_64)
-    ANDROID_IMG_URL="${ANDROID13_TV_IMG_X86[0]}"
-    ANDROID_IMG_SHA="${ANDROID13_TV_IMG_X86[1]}"
-  ;;
-  esac
-
-  echo_info "[+] Installing ${CYAN}${ANDROID_VERSION}${RESET}"
-
-  sudo mkdir -p /etc/waydroid-extra/images
-  cd /etc/waydroid-extra/images
-
-  if [ ! -f android13.zip ]; then
-    echo_info '[+] Downloading Android 13 image...'
-    sudo curl -L "${ANDROID_IMG_URL}" -o android13.zip
-  fi
-
-  echo_info '[+] Verifying archive...'
-  sha256sum -c - <<< "${ANDROID_IMG_SHA} android13.zip"
-
-  echo_info '[+] Decompressing Android 13 image...'
-  sudo unzip android13.zip
-  sudo rm android13.zip
-
-  echo_info '[+] Initializing system...'
-  sudo waydroid init -f
+  echo_info "[+] Installing ${CYAN}Android 13 FOSS${RESET}"
+  sudo waydroid init -s FOSS
+;;
+3)
+  echo_info "[+] Installing ${CYAN}Android 13 GAPPS${RESET}"
+  sudo waydroid init -s GAPPS
 ;;
 esac
 


### PR DESCRIPTION
This pull request updates the installer scripts for Waydroid on ChromeOS, focusing on changing repository sources and simplifying Android image selection and installation. The main changes include updating download URLs to a new repository, removing manual handling for Android TV images, and streamlining the installation options for Android 13 variants.

**Repository and source updates:**
* Changed the `REPO_URL` in both `01-setup_lxd.sh` and `02-setup_waydroid.sh` to point to `neilgfoster/cros-waydroid-installer` instead of `supechicken/ChromeOS-Waydroid-Installer`. [[1]](diffhunk://#diff-aee675db1b06b107e1c3046a5334d3dbf3dda886b71814aa60dc8cf3823e33f4L6-R6) [[2]](diffhunk://#diff-674704d8cca5d128a434b5e97180f0d0d7864ec2307d610b1bd93d367be21d2aL6-R6)

**Simplification of Android image selection and installation:**
* Removed manual download and verification logic for Android 13 TV images, including the related variables and case handling. [[1]](diffhunk://#diff-674704d8cca5d128a434b5e97180f0d0d7864ec2307d610b1bd93d367be21d2aL6-R6) [[2]](diffhunk://#diff-674704d8cca5d128a434b5e97180f0d0d7864ec2307d610b1bd93d367be21d2aL78-R74)
* Updated the Android version selection menu to offer "Android 13 FOSS" and "Android 13 GAPPS" instead of "Android 13 TV".
* Streamlined the installation process for Android 13 variants to use the built-in `waydroid init -s` options for FOSS and GAPPS, eliminating the need for separate image downloads and manual verification.