### PR TITLE
feature/foss-gapps

### DIFF
--- a/scripts/start-waydroid
+++ b/scripts/start-waydroid
@@ -28,6 +28,7 @@ fi
 waydroid session stop
 
 # start waydroid with cage
+(
 sommelier --direct-scale -X bash -eu <<'EOF'
   export ORIGDISP=$DISPLAY
   unset WAYLAND_DISPLAY
@@ -38,4 +39,4 @@ sommelier --direct-scale -X bash -eu <<'EOF'
     waydroid -q show-full-ui
   ' 2> /dev/null
 EOF
-&
+) &


### PR DESCRIPTION
This pull request updates the startup script for Waydroid to improve how the session is launched with Cage and Sommelier. The main change is switching from using `exec` to running the command in a background subshell, which allows the script to continue after starting Waydroid.

Process management improvements:

* Changed the Waydroid startup command from `exec sommelier ...` to running Sommelier in a subshell and backgrounding it, enabling the script to proceed without waiting for Waydroid to exit.

Command-line options and output handling:

* Added the `-q` (quiet) flag to the `waydroid show-full-ui` command to reduce output noise during startup.
* Redirected error output to `/dev/null` to suppress unwanted error messages from Cage.