### PR TITLE
feature/lineage-options

### DIFF
--- a/installer/02-setup_waydroid.sh
+++ b/installer/02-setup_waydroid.sh
@@ -102,25 +102,25 @@ case "${ANDROID_VERSION}" in
         SYSTEM_IMAGE="lineage-20.0-20250809-GAPPS-waydroid_x86_64-system.zip"
         ;;
     esac
-    VENDOR_IMAGE_URL="https://sourceforge.net/projects/waydroid/files/images/vendor/lineage/waydroid_x86_64/${VENDOR_IMAGE}"
+    VENDOR_IMAGE_URL="https://sourceforge.net/projects/waydroid/files/images/vendor/waydroid_x86_64/${VENDOR_IMAGE}"
     SYSTEM_IMAGE_URL="https://sourceforge.net/projects/waydroid/files/images/system/lineage/waydroid_x86_64/${SYSTEM_IMAGE}"
 
     # Create and clean image directory
     sudo mkdir -p /etc/waydroid-extra/images
     cd /etc/waydroid-extra/images
-    rm -rf *
+    sudo rm -rf *
 
     # Download and extract vendor image
     echo_info "[+] Downloading vendor image..."
     sudo curl -L "${VENDOR_IMAGE_URL}" -o "${VENDOR_IMAGE}"
     sudo unzip ${VENDOR_IMAGE}
-    rm -f ${VENDOR_IMAGE}
+    sudo rm -f ${VENDOR_IMAGE}
 
     # Download and extract system image
     echo_info "[+] Downloading system image..."
     sudo curl -L "${SYSTEM_IMAGE_URL}" -o "${SYSTEM_IMAGE}"
     sudo unzip ${SYSTEM_IMAGE}
-    rm -f ${SYSTEM_IMAGE}
+    sudo rm -f ${SYSTEM_IMAGE}
 
     # Initialize Waydroid with downloaded images
     echo_info '[+] Initializing system...'


### PR DESCRIPTION
This pull request updates the `installer/02-setup_waydroid.sh` script to significantly expand the Android installation options and improve the installation flow for Waydroid. The most important changes include expanding the menu to support more Android versions and variants, automating the download and extraction of system/vendor images, and refining the initialization logic.

**Expanded Android installation options and improved setup flow:**

* The Android version selection menu now supports eight options, including various LineageOS releases and both VANILLA and GAPPS variants, instead of just three Android 13 options.
* The script now automates downloading and extracting the appropriate system and vendor images from SourceForge for LineageOS options, based on the user's menu selection.
* Initialization logic is updated: for LineageOS options, the script downloads images, cleans the target directory, extracts the images, and runs `waydroid init -f`; for default options, it uses the simplified `waydroid init -s` command.
* The installer now mounts the binder filesystem and creates loopback devices as part of the setup, ensuring the environment is ready for Waydroid. [[1]](diffhunk://#diff-674704d8cca5d128a434b5e97180f0d0d7864ec2307d610b1bd93d367be21d2aR31) [[2]](diffhunk://#diff-674704d8cca5d128a434b5e97180f0d0d7864ec2307d610b1bd93d367be21d2aR42)
* The repository URL for additional resources is now set at the start of the script, improving maintainability.