### PR TITLE
fix/shortcut-locations

### DIFF
--- a/scripts/start-waydroid
+++ b/scripts/start-waydroid
@@ -3,6 +3,9 @@ IPROUTE_CMD='ip route add default via 192.168.240.1'
 
 # Cleanup waydroid shortcuts
 sudo rm -f ~/.local/share/applications/*.desktop
+sudo rm -f /usr/share/applications/python*.desktop
+sudo rm -f /usr/share/applications/vim*.desktop
+sudo rm -f /usr/share/applications/waydroid*.desktop
 
 # setup binderfs/loopback devices if not already done
 if [ ! -c /dev/loop-control ]; then

--- a/scripts/stop-waydroid
+++ b/scripts/stop-waydroid
@@ -5,3 +5,6 @@ waydroid session stop
 
 # Cleanup waydroid shortcuts
 sudo rm -f ~/.local/share/applications/*.desktop
+sudo rm -f /usr/share/applications/python*.desktop
+sudo rm -f /usr/share/applications/vim*.desktop
+sudo rm -f /usr/share/applications/waydroid*.desktop


### PR DESCRIPTION
This pull request adds additional cleanup steps to both the `start-waydroid` and `stop-waydroid` scripts. The main change is the removal of specific `.desktop` shortcut files from the `/usr/share/applications` directory to ensure a cleaner environment before and after running Waydroid.

Shortcut cleanup enhancements:

* Both `scripts/start-waydroid` and `scripts/stop-waydroid` now remove `.desktop` files related to Python, Vim, and Waydroid from `/usr/share/applications` in addition to the existing cleanup in `~/.local/share/applications`. [[1]](diffhunk://#diff-cf568b164b9d82bf052069d2d26ab17a104c16ae11808d4ee5176a44919691bcR6-R8) [[2]](diffhunk://#diff-5b04328d534f47e9b0a71978fb1d587bbfd8658b42117a908e406f3255b812cdR8-R10)